### PR TITLE
fixes for macos and arm

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -60,7 +60,7 @@ download_release() {
   fi
 
   # url="https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}-${OS}-${ARCH}.tar.gz"
-  url = "https://cli-assets.heroku.com/channels/stable/heroku-${OS}-${ARCH}.tar.gz"
+  url= "https://cli-assets.heroku.com/channels/stable/heroku-${OS}-${ARCH}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -7,7 +7,7 @@ TOOL_NAME="heroku-cli"
 TOOL_TEST="heroku --help"
 
 fail() {
-  echo -e "asdf-$TOOL_NAME: $*"
+  echo -e "mise-$TOOL_NAME: $*"
   exit 1
 }
 
@@ -59,7 +59,8 @@ download_release() {
     exit 1
   fi
 
-  url="https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}-${OS}-${ARCH}.tar.gz"
+  # url="https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}-${OS}-${ARCH}.tar.gz"
+  url = "https://cli-assets.heroku.com/channels/stable/heroku-${OS}-${ARCH}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
@@ -71,7 +72,7 @@ install_version() {
   local install_path="$3"
 
   if [ "$install_type" != "version" ]; then
-    fail "asdf-$TOOL_NAME supports release installs only"
+    fail "mise-$TOOL_NAME supports release installs only"
   fi
 
   (

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -59,7 +59,6 @@ download_release() {
     exit 1
   fi
 
-  # url="https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}-${OS}-${ARCH}.tar.gz"
   url="https://cli-assets.heroku.com/channels/stable/heroku-${OS}-${ARCH}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -60,7 +60,7 @@ download_release() {
   fi
 
   # url="https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}-${OS}-${ARCH}.tar.gz"
-  url= "https://cli-assets.heroku.com/channels/stable/heroku-${OS}-${ARCH}.tar.gz"
+  url="https://cli-assets.heroku.com/channels/stable/heroku-${OS}-${ARCH}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -43,17 +43,19 @@ download_release() {
   elif [ "$(uname -s)" == "Linux" ]; then
     OS=linux
   else
-    echoerr "This installer is only supported on Linux and MacOS"
+    fail "This installer is only supported on Linux and MacOS"
     exit 1
   fi
 
   ARCH="$(uname -m)"
-  if [ "$ARCH" == "x86_64" ]; then
+  if [ "$ARCH" == "x86_64" ] || [ "$OS" == "darwin" ]; then
     ARCH=x64
   elif [[ "$ARCH" == aarch* ]]; then
     ARCH=arm
+  elif [[ "$ARCH" == arm* ]]; then
+    ARCH=arm
   else
-    echoerr "unsupported arch: $ARCH"
+    fail "unsupported arch: $ARCH"
     exit 1
   fi
 


### PR DESCRIPTION
there is no arm version available for macos so we must use x64. Also that `echoerr` function was not defined which causes this error:

```
/Users/jdxcode/.asdf/plugins/heroku-cli/lib/utils.bash: line 56: echoerr: command not found
```

These issues are the same in asdf and rtx.